### PR TITLE
本番で動くようにした

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,0 +1,9 @@
+<template>
+	<div></div>
+</template>
+
+<script>
+export default {
+	beforeCreate () { this.$router.push('/') }
+}
+</script>

--- a/main.js
+++ b/main.js
@@ -1,29 +1,36 @@
 /*
-**  Nuxt
-*/
-const http = require('http')
-const { Nuxt, Builder } = require('nuxt')
+ **  Nuxt
+ */
 let config = require('./nuxt.config.js')
-config.rootDir = __dirname // for electron-builder
-// Init Nuxt.js
-const nuxt = new Nuxt(config)
-const builder = new Builder(nuxt)
-const server = http.createServer(nuxt.render)
+let _NUXT_URL_ = null
+const http = require('http')
 // Build only in dev mode
 if (config.dev) {
+	const {
+		Nuxt,
+		Builder
+	} = require('nuxt')
+	const nuxt = new Nuxt(config)
+	const builder = new Builder(nuxt)
+	const server = http.createServer(nuxt.render)
 	builder.build().catch(err => {
 		console.error(err) // eslint-disable-line no-console
 		process.exit(1)
 	})
+	// Listen the server
+	server.listen()
+	_NUXT_URL_ = `http://localhost:${server.address().port}`
+} else {
+	_NUXT_URL_ = `file://${__dirname}/index.html`
 }
-// Listen the server
-server.listen()
-const _NUXT_URL_ = `http://localhost:${server.address().port}`
 console.log(`Nuxt working on ${_NUXT_URL_}`)
 
 /*
-** Electron
-*/
+ ** Electron
+ */
+require('electron-debug')({
+	showDevTools: true
+})
 let win = null // Current window
 const electron = require('electron')
 const path = require('path')
@@ -36,19 +43,25 @@ const newWin = () => {
 	win.on('closed', () => win = null)
 	if (config.dev) {
 		// Install vue dev tool and open chrome dev tools
-		const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer')
-		installExtension(VUEJS_DEVTOOLS.id).then(name => {
-			console.log(`Added Extension:  ${name}`)
-			win.webContents.openDevTools()
-		}).catch(err => console.log('An error occurred: ', err))
+		const {
+			default: installExtension,
+			VUEJS_DEVTOOLS
+		} = require('electron-devtools-installer')
+		installExtension(VUEJS_DEVTOOLS.id).catch(err => console.log('An error occurred: ', err))
 		// Wait for nuxt to build
 		const pollServer = () => {
 			http.get(_NUXT_URL_, (res) => {
-				if (res.statusCode === 200) { win.loadURL(_NUXT_URL_) } else { setTimeout(pollServer, 300) }
+				if (res.statusCode === 200) {
+					win.loadURL(_NUXT_URL_)
+				} else {
+					setTimeout(pollServer, 300)
+				}
 			}).on('error', pollServer)
 		}
 		pollServer()
-	} else { return win.loadURL(_NUXT_URL_) }
+	} else {
+		win.loadURL(_NUXT_URL_)
+	}
 }
 app.on('ready', newWin)
 app.on('window-all-closed', () => app.quit())

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,16 @@
-module.exports = {
+const prodRouterBase = process.env.NODE_ENV === 'DEV' ? {} : {
+  router: {
+    base: './'
+  }
+}
+
+module.exports = { ...prodRouterBase,
   mode: 'spa',
   head: {title: 'lgtm-cabinet'}, // Headers of the page
   loading: false, // Disable default loading bar
+  generate: {
+    dir: 'dist/electron'
+  },
   build: {
     extend (config, { isDev, isClient }) {
       if (isDev && isClient) {
@@ -40,4 +49,5 @@ module.exports = {
       ]
     ],
   ],
+  rootDir: __dirname
 }

--- a/package.json
+++ b/package.json
@@ -4,18 +4,22 @@
   "description": "Nuxt + Electron",
   "author": "uucyan <uuunouucyan@gmail.com>",
   "private": true,
-  "main": "main.js",
+  "main": "./dist/electron/main.js",
   "build": {
     "appId": "com.uucyan.app",
     "directories": {
       "buildResources": "static"
-    }
+    },
+    "files": [
+      "dist/electron/**/*"
+    ]
   },
   "scripts": {
-    "dev": "cross-env NODE_ENV=DEV electron .",
-    "build": "nuxt build && electron-builder"
+    "dev": "cross-env NODE_ENV=DEV electron ./main.js",
+    "build": "nuxt generate && cp main.js dist/electron/ && cp nuxt.config.js dist/electron/ && electron-builder"
   },
   "dependencies": {
+    "electron-debug": "^1.5.0",
     "element-ui": "^2.4.0",
     "nedb": "^1.8.0",
     "nuxt": "^1.4.0"

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -1,18 +1,19 @@
 import Vue from 'vue'
 import Datastore from 'nedb'
+import { remote } from 'electron'
+import path from 'path'
 
 let db = {}
+const filePath = path.join(remote.app.getPath('userData'), '/db')
+
 db.folders = new Datastore({
   autoload: true,
-  filename: 'plugins/db/folders.db'
+  filename: `${filePath}/folders.db`
 })
 db.config = new Datastore({
   autoload: true,
-  filename: 'plugins/db/config.db'
+  filename: `${filePath}/config.db`
 })
-
-db.folders.loadDatabase()
-db.config.loadDatabase()
 
 // すべての Component から db を使用できるように、Vue のプロトタイプに追加する。
 // 各 Component で使用する際は this.$db.config のように参照する。

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,6 +2321,13 @@ electron-builder@^20.8.1:
     update-notifier "^2.5.0"
     yargs "^12.0.1"
 
+electron-debug@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/electron-debug/-/electron-debug-1.5.0.tgz#d88c02146efb7fc5ae1b21eac56fbe4987eae50c"
+  dependencies:
+    electron-is-dev "^0.3.0"
+    electron-localshortcut "^3.0.0"
+
 electron-devtools-installer@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763"
@@ -2343,6 +2350,23 @@ electron-download@^3.0.1:
     rc "^1.1.2"
     semver "^5.3.0"
     sumchecker "^1.2.0"
+
+electron-is-accelerator@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
+
+electron-is-dev@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
+
+electron-localshortcut@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-3.1.0.tgz#10c1ffd537b8d39170aaf6e1551341f7780dd2ce"
+  dependencies:
+    debug "^2.6.8"
+    electron-is-accelerator "^0.1.0"
+    keyboardevent-from-electron-accelerator "^1.1.0"
+    keyboardevents-areequal "^0.2.1"
 
 electron-osx-sign@0.4.10:
   version "0.4.10"
@@ -3919,6 +3943,14 @@ jstransformer@1.0.0:
   dependencies:
     is-promise "^2.0.0"
     promise "^7.0.1"
+
+keyboardevent-from-electron-accelerator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-1.1.0.tgz#324614f6e33490c37ffc5be5876b3e85fe223c84"
+
+keyboardevents-areequal@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
本番向けにbuildして動くようにした。
そう、動くようにした。

## アプリを本番で動くようにする方法*
下記PRの変更差分を自分のProjectにすべてコピペした。
https://github.com/nuxt-community/electron-template/pull/20

portではなく静的ファイルとしてbuildしたものを読み込むようしてるっぽい。

## neDBを本番で動くようにする方法*
dbファイルのパス指定の仕方が元々悪かった。
ElectronのAPIで提供されている、 `app.getPath(name)` を利用してあげる。
https://simulatedgreg.gitbooks.io/electron-vue/ja/savingreading-local-files.html
https://electronjs.org/docs/api/app#appgetpathname