### PR TITLE
アプリケーション名を「LGTM Cabinet」に変更

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,7 +7,7 @@ const prodRouterBase = process.env.NODE_ENV === 'DEV' ? {} : {
 module.exports = { ...prodRouterBase,
   mode: 'spa',
   head: {
-    title: 'lgtm-cabinet',
+    title: 'LGTM Cabinet',
     meta: [
       { charset: 'utf-8' }
     ]

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "lgtm-cabinet",
   "version": "1.0.0",
-  "description": "Nuxt + Electron",
+  "description": "LGTM 画像を管理できて簡単にコピーできるアプリ。",
   "author": "uucyan <uuunouucyan@gmail.com>",
   "private": true,
   "main": "./dist/electron/main.js",
   "build": {
     "appId": "com.uucyan.app",
+    "productName": "LGTM Cabinet",
+    "copyright": "Copyright © 2019 Uucyan",
     "directories": {
       "buildResources": "static"
     },


### PR DESCRIPTION
「lgtm-cabinet」になっていたので、正式名称となる「LGTM Cabinet」に変更。

- 名前の設定方法
  - https://www.electron.build/configuration/configuration#configuration

<img width="1083" alt="2019-01-02 4 13 21" src="https://user-images.githubusercontent.com/19953599/50575640-3074bd00-0e45-11e9-98be-920599dc4257.png">
