### PR TITLE
外部サービスの「TheDogAPI」から画像を取得してコピーできるようにした

### DIFF
--- a/components/TheMainView.vue
+++ b/components/TheMainView.vue
@@ -4,6 +4,7 @@ el-container
   main-view-config(v-show="selectedMenu == 'config'")
   main-view-image-list(v-show="selectedMenu == 'folder'")
   main-view-the-cat-api(v-if="selectedMenu == 'theCatApi'")
+  main-view-the-dog-api(v-if="selectedMenu == 'theDogApi'")
   main-view-top(v-show="selectedMenu == ''")
 </template>
 
@@ -13,6 +14,7 @@ import MainViewFolderManagement from '~/components/main/MainViewFolderManagement
 import MainViewConfig from '~/components/main/MainViewConfig.vue'
 import MainViewImageList from '~/components/main/MainViewImageList.vue'
 import MainViewTheCatApi from '~/components/main/MainViewTheCatApi.vue'
+import MainViewTheDogApi from '~/components/main/MainViewTheDogApi.vue'
 
 export default
   name: 'MainView'
@@ -24,6 +26,7 @@ export default
     'main-view-config': MainViewConfig
     'main-view-image-list': MainViewImageList
     'main-view-the-cat-api': MainViewTheCatApi
+    'main-view-the-dog-api': MainViewTheDogApi
 </script>
 
 <style lang="sass" scoped>

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -37,6 +37,12 @@ section.wood-grain-dark-brown
       )
         i.el-icon-picture-outline
         span TheCatAPI.com
+      el-menu-item(
+        index='3-2',
+        @click="select('theDogApi')"
+      )
+        i.el-icon-picture-outline
+        span TheDogAPI.com
     el-submenu(index='4')
       template(slot='title')
         span フォルダ

--- a/components/main/MainViewConfig.vue
+++ b/components/main/MainViewConfig.vue
@@ -103,7 +103,33 @@ el-container.main
         br
         | ※ マークダウン形式にした場合、 "[![LGTM](https://hogehoge)](https://hogehoge)" の形式でコピーします
       el-select.input(v-model='theCatApiCopyFormat', @change="updateConfig('theCatApiCopyFormat', theCatApiCopyFormat)",  placeholder='選択')
-        el-option(v-for='item in theCatApiCopyFormatOption', :key='item.value', :label='item.label', :value='item.value')
+        el-option(v-for='item in copyFormatOption', :key='item.value', :label='item.label', :value='item.value')
+    div.margin-bottom-20px
+
+    div.config-title
+      i.el-icon-share
+      span TheDogAPI.com
+    div.form-item
+      label.form-label
+        | デフォルトの一度に取得する画像の枚数
+        br
+        | ※ 1枚 〜 27枚まで指定可能です
+      el-input-number.input(v-model='theDogApiDefaultLimit', @change="updateConfig('theDogApiDefaultLimit', theDogApiDefaultLimit)", :max="27", :min="1")
+      span.input-append-text 枚
+    div.form-item
+      label.form-label
+        | デフォルトの取得する画像の形式
+        br
+        | ※ 何も選択していない場合、すべての条件で検索されます
+      el-checkbox-group.input(v-model='theDogApiDefaultMimeTypes')
+        el-checkbox-button(v-for='mimeType in mimeTypeOptions', @change="updateConfig('theDogApiDefaultMimeTypes', theDogApiDefaultMimeTypes)", :label='mimeType', :key='mimeType') {{mimeType}}
+    div.form-item
+      label.form-label
+        | 画像のコピー形式
+        br
+        | ※ マークダウン形式にした場合、 "[![LGTM](https://hogehoge)](https://hogehoge)" の形式でコピーします
+      el-select.input(v-model='theDogApiCopyFormat', @change="updateConfig('theDogApiCopyFormat', theDogApiCopyFormat)",  placeholder='選択')
+        el-option(v-for='item in copyFormatOption', :key='item.value', :label='item.label', :value='item.value')
   reset-config-confirm-dialog(
     :message="resetConfirmMessage",
     @close="hideConfirmDialog"
@@ -133,6 +159,9 @@ export default
     theCatApiDefaultLimit: 9
     theCatApiDefaultMimeTypes: ['jpg', 'png', 'gif']
     theCatApiCopyFormat: 'markdown'
+    theDogApiDefaultLimit: 9
+    theDogApiDefaultMimeTypes: ['jpg', 'png', 'gif']
+    theDogApiCopyFormat: 'markdown'
     notificationPositionOptions: [
       {
         value: 'top-right'
@@ -171,7 +200,7 @@ export default
         label: '降順'
       },
     ]
-    theCatApiCopyFormatOption: [
+    copyFormatOption: [
       {
         value: 'markdown'
         label: 'マークダウン'
@@ -201,6 +230,9 @@ export default
       @theCatApiDefaultLimit = @config.theCatApiDefaultLimit
       @theCatApiDefaultMimeTypes = @config.theCatApiDefaultMimeTypes
       @theCatApiCopyFormat = @config.theCatApiCopyFormat
+      @theDogApiDefaultLimit = @config.theDogApiDefaultLimit
+      @theDogApiDefaultMimeTypes = @config.theDogApiDefaultMimeTypes
+      @theDogApiCopyFormat = @config.theDogApiCopyFormat
       # フォルダのソートを適用
       @$store.dispatch('folders/findAll', {config: @config, isUpdate: false})
 

--- a/components/main/MainViewTheCatAPI.vue
+++ b/components/main/MainViewTheCatAPI.vue
@@ -2,7 +2,7 @@
 el-container.main
   el-header.wood-grain-dark-brown.z-index-1(height='85px' style='padding: 20px 20px 0px 20px; filter: drop-shadow(10px 10px 10px rgba(0,0,0,0.5));')
     div.display-table
-      p.header-element-left2.header-title.overflow-x-auto TheCatAPI.com
+      a.header-element-left2.header-title.overflow-x-auto(href="https://thecatapi.com/" target="_blank") TheCatAPI.com
       div.header-element-right2
         el-popover(placement='top', v-model='searchOptionVisible')
           div.form-item

--- a/components/main/MainViewTheDogApi.vue
+++ b/components/main/MainViewTheDogApi.vue
@@ -2,7 +2,7 @@
 el-container.main
   el-header.wood-grain-dark-brown.z-index-1(height='85px' style='padding: 20px 20px 0px 20px; filter: drop-shadow(10px 10px 10px rgba(0,0,0,0.5));')
     div.display-table
-      p.header-element-left2.header-title.overflow-x-auto TheDogAPI.com
+      a.header-element-left2.header-title.overflow-x-auto(href="https://thedogapi.com/" target="_blank") TheDogAPI.com
       div.header-element-right2
         el-popover(placement='top', v-model='searchOptionVisible')
           div.form-item

--- a/components/main/MainViewTheDogApi.vue
+++ b/components/main/MainViewTheDogApi.vue
@@ -1,0 +1,203 @@
+<template lang="pug">
+el-container.main
+  el-header.wood-grain-dark-brown.z-index-1(height='85px' style='padding: 20px 20px 0px 20px; filter: drop-shadow(10px 10px 10px rgba(0,0,0,0.5));')
+    div.display-table
+      p.header-element-left2.header-title.overflow-x-auto TheDogAPI.com
+      div.header-element-right2
+        el-popover(placement='top', v-model='searchOptionVisible')
+          div.form-item
+            label.form-label
+              | 一度に取得する画像の枚数
+              br
+              | ※ 1枚 〜 27枚まで指定可能です
+            el-input-number.input(v-model='limit', :max="27", :min="1")
+            span.input-append-text 枚
+          div.form-item
+            label.form-label
+              | 取得する画像の形式
+              br
+              | ※ 何も選択していない場合、すべての条件で検索されます
+            el-checkbox-group.input(v-model='mimeTypes')
+              el-checkbox-button(v-for='mimeType in mimeTypeOptions', :label='mimeType', :key='mimeType') {{mimeType}}
+          div.margin-bottom-20px
+          div(style='text-align: right; margin: 0')
+            el-button(type='text', @click='searchOptionVisible = false') 閉じる
+            el-button(type='primary', @click='getDogImages()') 画像の再取得
+            div.margin-bottom-10px
+            p ※ 画像の取得は必ずランダムです
+          div.margin-bottom-20px
+          el-button(
+            v-if="windowWidthSize > 830"
+            slot='reference'
+            icon='el-icon-search'
+            style='background: transparent; color: #ffffff;'
+          ) 取得条件
+          el-button(
+            v-else
+            slot='reference'
+            circle
+            icon='el-icon-search'
+            style='background: transparent; color: #ffffff;'
+          )
+
+      div.header-element-right2(v-if="windowWidthSize > 830", style='width: 160px;')
+        el-button(
+          icon='el-icon-printer'
+          @click="randomSelectImage()"
+          v-bind:disabled='!isExistsImages'
+          style='background: transparent; color: #ffffff;'
+        ) ランダムコピー
+      div.header-element-right2(v-else, style='width: 50px;')
+        el-button(
+          circle
+          icon='el-icon-printer'
+          @click="randomSelectImage()"
+          v-bind:disabled='!isExistsImages'
+          style='background: transparent; color: #ffffff;'
+        )
+  el-main.wood-grain-white(id='image-list', v-loading="loading")
+    ul.itemlist.z-index-0
+      li(v-for="image in images")
+        img(
+          :src="image.url"
+          @click="copyToClipboard(image)"
+        )
+</template>
+
+<script lang="coffee">
+import HandleResizeMixin from "~/components/main/HandleResizeMixin.coffee"
+import axios from 'axios'
+
+{ clipboard } = require('electron')
+
+export default
+  name: 'MainViewTheDogApi'
+  mixins: [ HandleResizeMixin ]
+  data: ->
+    images: []
+    loading: true
+    searchOptionVisible: false
+    limit: 9
+    mimeTypes: ['jpg', 'png', 'gif']
+    mimeTypeOptions: ['jpg', 'png', 'gif']
+
+  computed:
+    config: -> @$store.state.config.config
+    isExistsImages: -> @images.length > 0
+
+  created: ->
+    @limit = @config.theDogApiDefaultLimit
+    @mimeTypes = @config.theDogApiDefaultMimeTypes
+    @getDogImages()
+
+  methods:
+    # TheDogAPI から画像を取得
+    getDogImages: ->
+      @loading = true
+      @searchOptionVisible = false
+      @images = []
+      axios.defaults.headers.common['x-api-key'] = '0f1c7b58-c06d-4e6d-a2c1-ff1c2ef8424f'
+      response = await axios.get(
+        'https://api.thedogapi.com/v1/images/search',
+        { params: { limit: @limit, size: "full", mime_types: @mimeTypes.join(','), order: 'Rand' } }
+      )
+      if response.status == 200 && response.data.length > 0
+        @images = response.data
+        @sendNotification('external_service_connection', 'success')
+      else
+        @sendNotification('external_service_connection', 'error')
+      @loading = false
+
+    # 画像をランダムで選択
+    randomSelectImage: ->
+      return @sendNotification('copy_image', 'warning') if !@isExistsImages
+      @copyToClipboard @images[Math.floor(Math.random() * Math.floor(@images.length))]
+
+    # 選択画像をクリップボードにコピー
+    copyToClipboard:(image) ->
+      if @config.theDogApiCopyFormat == 'markdown'
+        copyText = "[![LGTM](#{image.url})](#{image.url})"
+      else
+        copyText = image.url
+      clipboard.writeText(copyText)
+      @sendNotification('copy_image', 'success')
+
+    # 通知を送信
+    sendNotification:(category, type) ->
+      @$services.notification.notify(category, type, @config)
+
+</script>
+
+<style lang="sass" scoped>
+.display-table
+  display: table
+  width: 100%
+
+.header-element-left2
+  display: table-cell
+  vertical-align: middle
+
+.header-element-right2
+  display: table-cell
+  vertical-align: middle
+  text-align: right
+
+.margin-bottom-10px
+  margin-bottom: 10px
+
+.margin-bottom-20px
+  margin-bottom: 20px
+
+.input
+  width: 300px
+  margin-top: auto
+
+.form-item
+  display: flex
+  border-bottom: solid #573216 1px
+  padding: 1.5em 0 0.5em 1.5em
+
+.form-label
+  padding-right: 1.5em
+  width: 80%
+
+.input-append-text
+  margin-top: auto
+  margin-left: 10px
+  margin-right: 10px
+
+ul
+  padding: 0px
+
+img
+  cursor: pointer
+
+.itemlist
+  filter: drop-shadow(10px 10px 10px rgba(0,0,0,0.5))
+  margin: 0 auto
+  li
+    list-style: none
+    float: left
+    width: 33.333333%
+    padding: 10px
+    &:nth-child(3n+1)
+      clear: left
+  img
+    width: 100%
+    height: auto
+    cursor: pointer
+
+@media screen and (max-width: 1300px)
+  .itemlist li
+    width: 50%
+    &:nth-child(2n+1)
+      clear: left
+    &:nth-child(3n+1)
+      clear: none
+
+@media screen and (max-width: 1000px)
+  .itemlist li
+    width: 100%
+    &:nth-child(2n+1)
+      clear: none
+</style>

--- a/store/config.js
+++ b/store/config.js
@@ -19,6 +19,10 @@ export const state = () => ({
     theCatApiDefaultLimit: 9,
     theCatApiDefaultMimeTypes: ['jpg', 'png', 'gif'],
     theCatApiCopyFormat: 'markdown',
+    // TheDogAPI.com
+    theDogApiDefaultLimit: 9,
+    theDogApiDefaultMimeTypes: ['jpg', 'png', 'gif'],
+    theDogApiCopyFormat: 'markdown',
   },
   config: {}
 })

--- a/store/state.js
+++ b/store/state.js
@@ -3,7 +3,8 @@ export const state = () => ({
   // フォルダ管理：folderManagement
   // 設定：config
   // フォルダ：folder
-  // TheCatAPI：theCatApi
+  // TheCatAPI.com：theCatApi
+  // TheDogAPI.com：theDogApi
   selectedMenu: '',
   // 設定を初期化確認ダイアログの表示フラグ
   resetConfigConfirmDialogVisible: false,


### PR DESCRIPTION
<img width="1612" alt="2019-01-27 23 54 28" src="https://user-images.githubusercontent.com/19953599/51802595-0de09300-228f-11e9-8393-864d59e1deb6.png">

TheCatAPI のソース丸コピーなゴミ実装。